### PR TITLE
Fix MkDocs configuration and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,20 @@
-name: ci 
+name: CI
+
 on:
   push:
     branches:
-      - master 
+      - master
       - main
       - NikhilBase
+  pull_request:
+    branches:
+      - master
+      - main
+      - NikhilBase
+
 permissions:
   contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -21,4 +29,15 @@ jobs:
           path: .cache
       - run: pip install mkdocs-material
       - run: pip install pillow cairosvg
-      - run: mkdocs gh-deploy --force
+      - name: Debug - List directory contents
+        run: |
+          pwd
+          ls -R
+      - name: Deploy MkDocs
+        run: |
+          if [ -f "mkdocs.yml" ]; then
+            mkdocs gh-deploy --force
+          else
+            echo "mkdocs.yml not found. Please ensure it exists in the root of your repository."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           mkdir -p docs
           find . -maxdepth 1 -type f \( -name "*.md" -o -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" -o -name "*.gif" \) -exec mv {} docs/ \;
+          mv mkdocs.yml docs/
       - name: Debug - List directory contents
         run: |
           pwd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           mkdir -p docs
           find . -maxdepth 1 -type f \( -name "*.md" -o -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" -o -name "*.gif" \) -exec mv {} docs/ \;
-          mv mkdocs.yml docs/
       - name: Debug - List directory contents
         run: |
           pwd
           ls -R
       - name: Deploy MkDocs
-        run: mkdocs gh-deploy --force
+        run: |
+          mkdocs gh-deploy --force --config-file ./mkdocs.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,13 @@ jobs:
           path: .cache
       - run: pip install mkdocs-material
       - run: pip install pillow cairosvg
+      - name: Prepare docs directory
+        run: |
+          mkdir -p docs
+          find . -maxdepth 1 -type f \( -name "*.md" -o -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" -o -name "*.gif" \) -exec mv {} docs/ \;
       - name: Debug - List directory contents
         run: |
           pwd
           ls -R
       - name: Deploy MkDocs
-        run: |
-          if [ -f "mkdocs.yml" ]; then
-            mkdocs gh-deploy --force
-          else
-            echo "mkdocs.yml not found. Please ensure it exists in the root of your repository."
-            exit 1
-          fi
+        run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: "Kaas"
-docs_dir: 'docs'
+docs_dir: '.'
 site_dir: 'site'
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,3 +22,5 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - attr_list
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: "Kaas"
+docs_dir: '.'
 theme:
   name: material
   language: en

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "Kaas"
-docs_dir: '.'
-site_dir: 'site'
+docs_dir: 'docs'
+site_dir: '../site'
 theme:
   name: material
   language: en

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: "Kaas"
-docs_dir: '.'
+docs_dir: 'docs'
+site_dir: 'site'
 theme:
   name: material
   language: en


### PR DESCRIPTION
This PR addresses the MkDocs build issues in our CI workflow by making the following changes:

1. Updated `mkdocs.yml` to use a separate `docs` directory for documentation files.
2. Modified the CI workflow to create a `docs` directory and move relevant files into it.
3. Added debug steps to the workflow for better troubleshooting.

These changes should resolve the configuration errors related to `docs_dir` and `site_dir`, allowing the MkDocs build to complete successfully in our CI pipeline.

# Changes made:
- Updated `mkdocs.yml`
- Modified `.github/workflows/ci.yml`